### PR TITLE
update NIST URL format

### DIFF
--- a/macros/cvss/libcvss31.lua
+++ b/macros/cvss/libcvss31.lua
@@ -172,7 +172,8 @@ function cvss31.vector_string(vector, complexity, privileges, interaction, scope
 end
 
 function cvss31.get_vector_string_url(vector_string)
-    return "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?version=3.1&vector=" .. vector_string
+    url_compatible_vector = string.gsub(vector_string, "CVSS:3.1/", "")
+    return "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?version=3.1&vector=" .. url_compatible_vector
 end
 
 return cvss31


### PR DESCRIPTION
The generated URLs are not compatible with the current NIST website. It doesn't accept the vector part `CVSS:3.1`.

With the old version it generates this URL from the sample:
https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?version=3.1&vector=CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H
https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?version=3.1&vector=AV:A/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H (new)


This PR doesn't change the appearance of CVSS in the document.